### PR TITLE
feat: 캘린더 이벤트 타입을 심리적 성격 기반으로 변경 및 LLM 분류 기능 추가

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -1,6 +1,6 @@
-from pydantic import BaseModel
-from typing import Optional, List
-from datetime import datetime
+from pydantic import BaseModel, field_validator
+from typing import Optional, List, Union
+from datetime import datetime, date
 from enum import Enum
 
 # ==========================================
@@ -21,9 +21,26 @@ class Emotion(str, Enum):
 class DiaryEntryBase(BaseModel):
     """일기 기본 모델 (입력용)"""
     user_id: str
-    date: datetime
+    date: Union[datetime, str]  # datetime 또는 ISO 문자열 허용
     content: str
     emotion: Emotion
+    
+    @field_validator('date', mode='before')
+    @classmethod
+    def parse_date(cls, v):
+        """날짜 문자열을 datetime으로 변환"""
+        if isinstance(v, str):
+            # ISO 형식 또는 YYYY-MM-DD 형식 모두 처리
+            try:
+                # ISO 형식 시도 (2024-01-15T10:00:00)
+                if 'T' in v:
+                    return datetime.fromisoformat(v.replace('Z', '+00:00'))
+                # YYYY-MM-DD 형식 (2024-01-15)
+                else:
+                    return datetime.fromisoformat(v + 'T00:00:00')
+            except ValueError:
+                raise ValueError(f"Invalid date format: {v}")
+        return v
 
 class DiaryEntryCreate(DiaryEntryBase):
     """일기 생성 요청 모델 (프론트엔드에서 받을 때)"""
@@ -31,21 +48,26 @@ class DiaryEntryCreate(DiaryEntryBase):
 
 class DiaryEntry(DiaryEntryBase):
     """일기 응답 모델 (저장 후 반환할 때)"""
-    id: Optional[int] = None
+    id: Optional[Union[int, str]] = None  # Firebase는 문자열 ID를 반환할 수 있음
     created_at: Optional[datetime] = None
     
     class Config:
         from_attributes = True
+        json_encoders = {
+            datetime: lambda v: v.isoformat()  # datetime을 ISO 문자열로 직렬화
+        }
 
 # ==========================================
 # 캘린더 관련 모델
 # ==========================================
 class CalendarEventType(str, Enum):
-    """캘린더 이벤트 타입"""
-    EXAM = "EXAM"              # 시험
-    INTERVIEW = "INTERVIEW"    # 면접
-    MEETING = "MEETING"        # 회의
-    OTHER = "OTHER"            # 기타
+    """캘린더 이벤트 타입 - 심리적 성격 기반 분류"""
+    PERFORMANCE = "PERFORMANCE"    # 평가/성과: 긴장과 스트레스를 유발하는 일
+    SOCIAL = "SOCIAL"              # 사회/관계: 사람을 만나고 에너지를 쓰는 일
+    CELEBRATION = "CELEBRATION"    # 기념일: 축하하거나 챙겨야 하는 날
+    HEALTH = "HEALTH"              # 건강/치료: 신체/정신적 케어가 필요한 일
+    LEISURE = "LEISURE"            # 휴식/여가: 리프레시를 위한 일
+    ROUTINE = "ROUTINE"            # 일상/기타: 특별한 감정 소모가 없는 단순 일정
 
 class CalendarEventBase(BaseModel):
     """캘린더 이벤트 기본 모델"""

--- a/app/service/__init__.py
+++ b/app/service/__init__.py
@@ -1,0 +1,1 @@
+# Service layer for business logic

--- a/app/service/calendar_classifier.py
+++ b/app/service/calendar_classifier.py
@@ -1,0 +1,91 @@
+"""
+캘린더 이벤트 타입 분류 서비스
+
+LLM을 사용하여 캘린더 이벤트 제목을 분석하고 
+심리적 성격 기반으로 타입을 자동 분류합니다.
+"""
+try:
+    from langchain_upstage import ChatUpstage
+    LANGCHAIN_AVAILABLE = True
+except ImportError:
+    LANGCHAIN_AVAILABLE = False
+    print("⚠️  langchain_upstage가 설치되지 않았습니다. LLM 분류 기능을 사용할 수 없습니다.")
+
+from app.models.schemas import CalendarEventType
+from app.core.config import settings
+
+
+def classify_calendar_event_type(title: str) -> CalendarEventType:
+    """
+    LLM을 사용하여 캘린더 이벤트 제목을 분석하고 타입을 분류합니다.
+    
+    Args:
+        title: 캘린더 이벤트 제목 (예: "중간고사", "삼성 면접", "친구 생일파티")
+    
+    Returns:
+        CalendarEventType: 분류된 이벤트 타입 (PERFORMANCE, SOCIAL, CELEBRATION, HEALTH, LEISURE, ROUTINE)
+    
+    Examples:
+        >>> classify_calendar_event_type("중간고사")
+        CalendarEventType.PERFORMANCE
+        
+        >>> classify_calendar_event_type("친구 생일파티")
+        CalendarEventType.CELEBRATION
+        
+        >>> classify_calendar_event_type("병원 예약")
+        CalendarEventType.HEALTH
+    """
+    if not LANGCHAIN_AVAILABLE:
+        # langchain_upstage가 없으면 기본값으로 ROUTINE 반환
+        print("⚠️  langchain_upstage가 설치되지 않아 기본값(ROUTINE)을 반환합니다.")
+        return CalendarEventType.ROUTINE
+    
+    if not settings.UPSTAGE_API_KEY:
+        # API 키가 없으면 기본값으로 ROUTINE 반환
+        print("⚠️  UPSTAGE_API_KEY가 설정되지 않아 기본값(ROUTINE)을 반환합니다.")
+        return CalendarEventType.ROUTINE
+    
+    llm = ChatUpstage(api_key=settings.UPSTAGE_API_KEY)
+    
+    prompt = f"""다음 캘린더 이벤트 제목을 분석하여 심리적 성격에 따라 타입을 분류해주세요.
+
+제목: {title}
+
+가능한 타입과 예시:
+1. PERFORMANCE (평가/성과): 긴장과 스트레스를 유발하는 일
+   예: 시험, 면접, 발표, 과제 마감, 오디션, 대회
+
+2. SOCIAL (사회/관계): 사람을 만나고 에너지를 쓰는 일
+   예: 회식, 데이트, 동창회, 결혼식 참석, 친구 약속
+
+3. CELEBRATION (기념일): 축하하거나 챙겨야 하는 날
+   예: 생일, 기념일, 명절, 크리스마스
+
+4. HEALTH (건강/치료): 신체/정신적 케어가 필요한 일
+   예: 병원, 치과, 상담, 운동, 검진
+
+5. LEISURE (휴식/여가): 리프레시를 위한 일
+   예: 여행, 호캉스, 휴가, 영화 관람, 콘서트
+
+6. ROUTINE (일상/기타): 특별한 감정 소모가 없는 단순 일정
+   예: 알바, 회의, 미용실, 은행, 장보기
+
+위 제목의 심리적 성격을 분석하여 가장 적합한 타입 하나만 답변해주세요.
+답변 형식: 타입 이름만 (예: PERFORMANCE, SOCIAL, CELEBRATION, HEALTH, LEISURE, ROUTINE)
+"""
+    
+    try:
+        response = llm.invoke(prompt)
+        type_str = response.content.strip().upper()
+        
+        # Enum으로 변환
+        try:
+            return CalendarEventType(type_str)
+        except ValueError:
+            # 잘못된 타입이면 ROUTINE으로 기본값 반환
+            print(f"⚠️  잘못된 타입 반환: {type_str}, 기본값(ROUTINE) 사용")
+            return CalendarEventType.ROUTINE
+    except Exception as e:
+        # LLM 호출 실패 시 기본값 반환
+        print(f"⚠️  LLM 분류 실패: {e}, 기본값(ROUTINE) 사용")
+        return CalendarEventType.ROUTINE


### PR DESCRIPTION
- CalendarEventType을 명사 기반에서 심리적 성격 기반으로 변경 (PERFORMANCE, SOCIAL, CELEBRATION, HEALTH, LEISURE, ROUTINE)
- LLM을 사용한 자동 타입 분류 함수 추가 (calendar_classifier.py)